### PR TITLE
Add upload and download functionality on project basis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+*.nlz-storage-project
 
 # Folders
 _obj

--- a/command/opts.go
+++ b/command/opts.go
@@ -3,9 +3,9 @@ package command
 import (
 	"fmt"
 	"net/http"
-	"net/url"
+	// "net/url"
 	"os"
-	"strings"
+	// "strings"
 
 	"github.com/nerdalize/s3sync/s3sync"
 	"github.com/smartystreets/go-aws-auth"
@@ -22,23 +22,23 @@ type S3Opts struct {
 }
 
 //CreateS3Client uses command line options to create an s3 client
-func (opts *S3Opts) CreateS3Client(ep string) (s3 *s3sync.S3, err error) {
-	loc, err := url.Parse(ep)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse '%s' as url: %v", ep, err)
-	}
+func (opts *S3Opts) CreateS3Client() (s3 *s3sync.S3, err error) {
+	// loc, err := url.Parse(ep)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to parse '%s' as url: %v", ep, err)
+	// }
 
 	if os.Getenv("AWS_REGION") != "" {
 		opts.S3Host = fmt.Sprintf("s3-%s.amazonaws.com", os.Getenv("AWS_REGION"))
 	}
 
-	if loc.Host != "" {
-		opts.S3Host = loc.Host
-	}
+	// if loc.Host != "" {
+	// 	opts.S3Host = loc.Host
+	// }
 
-	if loc.Path != "" {
-		opts.S3Prefix = strings.Trim(loc.Path, "/")
-	}
+	// if loc.Path != "" {
+	// 	opts.S3Prefix = strings.Trim(loc.Path, "/")
+	// }
 
 	if opts.S3AccessKey == "" {
 		opts.S3AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
@@ -52,9 +52,9 @@ func (opts *S3Opts) CreateS3Client(ep string) (s3 *s3sync.S3, err error) {
 		opts.S3SessionToken = os.Getenv("AWS_SESSION_TOKEN")
 	}
 
-	if loc.Scheme != "" {
-		opts.S3Scheme = loc.Scheme
-	}
+	// if loc.Scheme != "" {
+	// 	opts.S3Scheme = loc.Scheme
+	// }
 
 	s3 = &s3sync.S3{
 		Scheme: opts.S3Scheme,

--- a/command/opts.go
+++ b/command/opts.go
@@ -3,9 +3,7 @@ package command
 import (
 	"fmt"
 	"net/http"
-	// "net/url"
 	"os"
-	// "strings"
 
 	"github.com/nerdalize/s3sync/s3sync"
 	"github.com/smartystreets/go-aws-auth"
@@ -23,22 +21,9 @@ type S3Opts struct {
 
 //CreateS3Client uses command line options to create an s3 client
 func (opts *S3Opts) CreateS3Client() (s3 *s3sync.S3, err error) {
-	// loc, err := url.Parse(ep)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("failed to parse '%s' as url: %v", ep, err)
-	// }
-
 	if os.Getenv("AWS_REGION") != "" {
 		opts.S3Host = fmt.Sprintf("s3-%s.amazonaws.com", os.Getenv("AWS_REGION"))
 	}
-
-	// if loc.Host != "" {
-	// 	opts.S3Host = loc.Host
-	// }
-
-	// if loc.Path != "" {
-	// 	opts.S3Prefix = strings.Trim(loc.Path, "/")
-	// }
 
 	if opts.S3AccessKey == "" {
 		opts.S3AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
@@ -51,10 +36,6 @@ func (opts *S3Opts) CreateS3Client() (s3 *s3sync.S3, err error) {
 	if opts.S3SessionToken == "" {
 		opts.S3SessionToken = os.Getenv("AWS_SESSION_TOKEN")
 	}
-
-	// if loc.Scheme != "" {
-	// 	opts.S3Scheme = loc.Scheme
-	// }
 
 	s3 = &s3sync.S3{
 		Scheme: opts.S3Scheme,

--- a/command/pull.go
+++ b/command/pull.go
@@ -92,7 +92,7 @@ func (cmd *Pull) DoRun(args []string) (err error) {
 		return fmt.Errorf("provided path '%s' is not a directory", args[0])
 	}
 
-	s3, err := cmd.opts.CreateS3Client(args[1])
+	s3, err := cmd.opts.CreateS3Client()
 	if err != nil {
 		return err
 	}

--- a/command/pull.go
+++ b/command/pull.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	uuid "github.com/hashicorp/go-uuid"
 	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
 	"github.com/nerdalize/s3sync/s3sync"
@@ -77,8 +78,6 @@ func (cmd *Pull) Run(args []string) int {
 	return 0
 }
 
-type Test []byte
-
 //DoRun is called by run and allows an error to be returned
 func (cmd *Pull) DoRun(args []string) (err error) {
 	if len(args) < 2 {
@@ -90,6 +89,8 @@ func (cmd *Pull) DoRun(args []string) (err error) {
 		return fmt.Errorf("failed to inspect '%s' for commit: %v", args[1], err)
 	} else if !fi.IsDir() {
 		return fmt.Errorf("provided path '%s' is not a directory", args[1])
+	} else if _, err = uuid.ParseUUID(args[0]); err != nil {
+		return fmt.Errorf("provided UUID '%v' is not valid: %v", args[0], err)
 	}
 
 	s3, err := cmd.opts.CreateS3Client()

--- a/command/pull.go
+++ b/command/pull.go
@@ -3,14 +3,11 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
 	"github.com/nerdalize/s3sync/s3sync"
-	"github.com/restic/chunker"
-	uuid "github.com/satori/go.uuid"
 )
 
 //PullOpts describes command options
@@ -32,7 +29,7 @@ func PullFactory() func() (cmd cli.Command, err error) {
 		ui:   &cli.BasicUi{Reader: os.Stdin, Writer: os.Stderr},
 	}
 
-	cmd.parser = flags.NewNamedParser("s3sync commit <DIR>", flags.Default)
+	cmd.parser = flags.NewNamedParser("s3sync pull <UUID> <DIR>", flags.Default)
 	_, err := cmd.parser.AddGroup("options", "options", cmd.opts)
 	if err != nil {
 		panic(err)
@@ -80,17 +77,19 @@ func (cmd *Pull) Run(args []string) int {
 	return 0
 }
 
+type Test []byte
+
 //DoRun is called by run and allows an error to be returned
 func (cmd *Pull) DoRun(args []string) (err error) {
 	if len(args) < 2 {
 		return fmt.Errorf("not enough arguments, use --help for more information")
 	}
 
-	fi, err := os.Stat(args[0])
+	fi, err := os.Stat(args[1])
 	if err != nil {
-		return fmt.Errorf("failed to inspect '%s' for commit: %v", args[0], err)
+		return fmt.Errorf("failed to inspect '%s' for commit: %v", args[1], err)
 	} else if !fi.IsDir() {
-		return fmt.Errorf("provided path '%s' is not a directory", args[0])
+		return fmt.Errorf("provided path '%s' is not a directory", args[1])
 	}
 
 	s3, err := cmd.opts.CreateS3Client()
@@ -98,25 +97,11 @@ func (cmd *Pull) DoRun(args []string) (err error) {
 		return err
 	}
 
-	done := make(chan struct{})
-	pr, pw := io.Pipe()
-	cr := chunker.New(pr, chunker.Pol(0x3DA3358B4DC173))
-	go func() {
-		err = s3sync.Upload(cr, &stdoutkw{}, 64, s3, uuid.UUID{})
-		if err != nil {
-			fmt.Println("ERROR", err)
-		}
-
-		done <- struct{}{}
-	}()
-
-	err = s3sync.Tar(args[0], pw)
+	//TODO: check for valid UUID (really stupid to blindly copy user input)
+	err = s3sync.DownloadProject(args[0], args[1], 64, s3)
 	if err != nil {
-		return fmt.Errorf("failed to tar '%s': %v", args[0], err)
+		return fmt.Errorf("could not download project: %v", err)
 	}
-
-	pw.Close()
-	<-done
 
 	return nil
 }

--- a/command/pull.go
+++ b/command/pull.go
@@ -6,10 +6,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/nerdalize/s3sync/s3sync"
 	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/nerdalize/s3sync/s3sync"
 	"github.com/restic/chunker"
+	uuid "github.com/satori/go.uuid"
 )
 
 //PullOpts describes command options
@@ -101,7 +102,7 @@ func (cmd *Pull) DoRun(args []string) (err error) {
 	pr, pw := io.Pipe()
 	cr := chunker.New(pr, chunker.Pol(0x3DA3358B4DC173))
 	go func() {
-		err = s3sync.Upload(cr, &stdoutkw{}, 64, s3)
+		err = s3sync.Upload(cr, &stdoutkw{}, 64, s3, uuid.UUID{})
 		if err != nil {
 			fmt.Println("ERROR", err)
 		}

--- a/command/push.go
+++ b/command/push.go
@@ -92,12 +92,12 @@ func (cmd *Push) DoRun(args []string) (err error) {
 		return fmt.Errorf("provided path '%s' is not a directory", args[0])
 	}
 
-	s3, err := cmd.opts.CreateS3Client(args[1])
+	s3, err := cmd.opts.CreateS3Client()
 	if err != nil {
 		return err
 	}
 
-	cmd.ui.Info(fmt.Sprintf("pushing to %s", s3.KeyURL(s3sync.ZeroKey[:])))
+	cmd.ui.Info(fmt.Sprintf("pushing to %s", s3.KeyURL(s3sync.BUCKET_CONTENT, s3sync.ZeroKey[:])))
 
 	doneCh := make(chan error)
 	pr, pw := io.Pipe()

--- a/command/utils.go
+++ b/command/utils.go
@@ -2,43 +2,14 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path"
 
 	"github.com/nerdalize/s3sync/s3sync"
-	uuid "github.com/satori/go.uuid"
 )
-
-//ProjectIDFile contains the nerdalize storage project ID for a given folder.
-const ProjectIDFile = ".nlz-storage-project"
 
 type stdoutkw struct{}
 
 func (kw *stdoutkw) Write(k s3sync.K) (err error) {
 	_, err = fmt.Fprintf(os.Stdout, "%x\n", k)
 	return err
-}
-
-//GetProjectID returns the nerdalize storage project ID for a given folder.
-func GetProjectID(dirPath string) (uuid.UUID, error) {
-	file := path.Join(dirPath, ProjectIDFile)
-	if _, err := os.Stat(file); os.IsNotExist(err) {
-		id := uuid.NewV4()
-		f, err := os.Create(file)
-		defer f.Close()
-		if err != nil {
-			return uuid.UUID{}, fmt.Errorf("could not create project ID file '%v': %v", file, err)
-		}
-		f.Write(id[:])
-		f.Sync()
-		return id, nil
-	}
-	dat, err := ioutil.ReadFile(file)
-	if err != nil {
-		return uuid.UUID{}, fmt.Errorf("could not read project ID file '%v': %v", file, err)
-	}
-	var id uuid.UUID
-	copy(id[:], dat)
-	return id, nil
 }

--- a/command/utils.go
+++ b/command/utils.go
@@ -2,14 +2,43 @@ package command
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path"
 
 	"github.com/nerdalize/s3sync/s3sync"
+	uuid "github.com/satori/go.uuid"
 )
+
+//ProjectIDFile contains the nerdalize storage project ID for a given folder.
+const ProjectIDFile = ".nlz-storage-project"
 
 type stdoutkw struct{}
 
 func (kw *stdoutkw) Write(k s3sync.K) (err error) {
 	_, err = fmt.Fprintf(os.Stdout, "%x\n", k)
 	return err
+}
+
+//GetProjectID returns the nerdalize storage project ID for a given folder.
+func GetProjectID(dirPath string) (uuid.UUID, error) {
+	file := path.Join(dirPath, ProjectIDFile)
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		id := uuid.NewV4()
+		f, err := os.Create(file)
+		defer f.Close()
+		if err != nil {
+			return uuid.UUID{}, fmt.Errorf("could not create project ID file '%v': %v", file, err)
+		}
+		f.Write(id[:])
+		f.Sync()
+		return id, nil
+	}
+	dat, err := ioutil.ReadFile(file)
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("could not read project ID file '%v': %v", file, err)
+	}
+	var id uuid.UUID
+	copy(id[:], dat)
+	return id, nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,20 +1,22 @@
-hash: bf45c7790c5e3d56a728551a7f06ec2551dc44a5060be25f4c26ba86cf41267d
-updated: 2016-12-30T16:51:23.888433038+01:00
+hash: 9647cc656a2b7bf026b19e0ebcccfdf595313b6500360f5514900e67b4d53470
+updated: 2017-01-12T10:56:55.125994088+01:00
 imports:
 - name: github.com/armon/go-radix
-  version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
+  version: 2ac111d378579ad421cd9dd4c658505325a22536
 - name: github.com/bgentry/speakeasy
-  version: 675b82c74c0ed12283ee81ba8a534c8982c07b85
+  version: 2ac111d378579ad421cd9dd4c658505325a22536
 - name: github.com/dchest/safefile
-  version: 855e8d98f1852d48dde521e0522408d1fe7e836a
+  version: ""
+- name: github.com/hashicorp/go-uuid
+  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
 - name: github.com/jessevdk/go-flags
-  version: 4e64e4a4e2552194cf594243e23aa9baf3b4297e
+  version: ""
 - name: github.com/mattn/go-isatty
-  version: 30a891c33c7cde7b02a981314b4228ec99380cca
+  version: 2ac111d378579ad421cd9dd4c658505325a22536
 - name: github.com/mitchellh/cli
-  version: fa17b36f6c61f1ddbbb08c9f6fde94b3c065a09d
+  version: ""
 - name: github.com/restic/chunker
-  version: 50428e727f50c16e1bcb3050209fc2758427a6af
+  version: ""
 - name: github.com/smartystreets/go-aws-auth
-  version: 2043e6d0bb7e4c18464a7bba562acbe482e3cabd
-testImports: []
+  version: ""
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,3 +12,5 @@ import:
   version: fa17b36f6c61f1ddbbb08c9f6fde94b3c065a09d
 - package: github.com/jessevdk/go-flags               #flexible flag parsing
   version: 4e64e4a4e2552194cf594243e23aa9baf3b4297e
+- package: github.com/hashicorp/go-uuid               #uuid generator
+  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
 		"push": command.PushFactory(),
+		"pull": command.PullFactory(),
 	}
 
 	status, err := c.Run()

--- a/s3sync/download.go
+++ b/s3sync/download.go
@@ -22,7 +22,7 @@ func Download(kr KeyReader, cw io.Writer, concurrency int, s3 *S3) (err error) {
 
 	work := func(it *item) {
 		var resp *http.Response
-		resp, err = s3.Get(it.k[:])
+		resp, err = s3.Get(BUCKET_CONTENT, it.k[:])
 		if err != nil {
 			it.resCh <- &result{fmt.Errorf("failed to get key '%x': %v", it.k, err), nil}
 			return

--- a/s3sync/download.go
+++ b/s3sync/download.go
@@ -22,7 +22,7 @@ func Download(kr KeyReader, cw io.Writer, concurrency int, s3 *S3) (err error) {
 
 	work := func(it *item) {
 		var resp *http.Response
-		resp, err = s3.Get(BUCKET_CONTENT, it.k[:])
+		resp, err = s3.Get(BucketContent, it.k[:])
 		if err != nil {
 			it.resCh <- &result{fmt.Errorf("failed to get key '%x': %v", it.k, err), nil}
 			return

--- a/s3sync/s3.go
+++ b/s3sync/s3.go
@@ -10,8 +10,8 @@ import (
 	"github.com/smartystreets/go-aws-auth"
 )
 
-const BUCKET_CONTENT = "content"
-const BUCKET_METADATA = "metadata"
+const BucketContent = "content"
+const BucketMetadata = "metadata"
 
 //S3 is A boring s3 client
 type S3 struct {

--- a/s3sync/s3.go
+++ b/s3sync/s3.go
@@ -23,7 +23,7 @@ type S3 struct {
 }
 
 //KeyURL returns the url to a key based on s3 config
-func (s3 *S3) KeyURL(bucket string, k []byte) string {
+func (s3 *S3) KeyURL(bucket string, k string) string {
 	// if s3.Prefix == "" {
 	// 	return fmt.Sprintf(
 	// 		"%s://%s/%x",
@@ -32,14 +32,14 @@ func (s3 *S3) KeyURL(bucket string, k []byte) string {
 	// }
 
 	return fmt.Sprintf(
-		"%s://%s/%s/%x",
+		"%s://%s/%s/%s",
 		s3.Scheme,
 		s3.Host,
 		bucket, k)
 }
 
 //Has attempts to download header info for an S3 k
-func (s3 *S3) Has(bucket string, k []byte) (has bool, err error) {
+func (s3 *S3) Has(bucket string, k string) (has bool, err error) {
 	raw := s3.KeyURL(bucket, k)
 	loc, err := url.Parse(raw)
 	if err != nil {
@@ -72,7 +72,7 @@ func (s3 *S3) Has(bucket string, k []byte) (has bool, err error) {
 }
 
 //Get attempts to download chunk 'k' from an S3 object store
-func (s3 *S3) Get(bucket string, k []byte) (resp *http.Response, err error) {
+func (s3 *S3) Get(bucket string, k string) (resp *http.Response, err error) {
 	raw := s3.KeyURL(bucket, k)
 	loc, err := url.Parse(raw)
 	if err != nil {
@@ -97,7 +97,7 @@ func (s3 *S3) Get(bucket string, k []byte) (resp *http.Response, err error) {
 }
 
 //Put uploads a chunk to an S3 object store under the provided key 'k'
-func (s3 *S3) Put(bucket string, k []byte, body io.Reader) error {
+func (s3 *S3) Put(bucket string, k string, body io.Reader) error {
 	raw := s3.KeyURL(bucket, k)
 	loc, err := url.Parse(raw)
 	if err != nil {

--- a/s3sync/s3.go
+++ b/s3sync/s3.go
@@ -24,13 +24,6 @@ type S3 struct {
 
 //KeyURL returns the url to a key based on s3 config
 func (s3 *S3) KeyURL(bucket string, k string) string {
-	// if s3.Prefix == "" {
-	// 	return fmt.Sprintf(
-	// 		"%s://%s/%x",
-	// 		s3.Scheme,
-	// 		s3.Host, k)
-	// }
-
 	return fmt.Sprintf(
 		"%s://%s/%s/%s",
 		s3.Scheme,

--- a/s3sync/s3sync.go
+++ b/s3sync/s3sync.go
@@ -1,8 +1,15 @@
 package s3sync
 
-import "crypto/sha256"
+import (
+	"crypto/sha256"
+	"fmt"
+)
 
 type K [sha256.Size]byte
+
+func (k K) ToString() string {
+	return fmt.Sprintf("%x", k)
+}
 
 var ZeroKey = K{}
 

--- a/s3sync/upload.go
+++ b/s3sync/upload.go
@@ -5,13 +5,60 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/restic/chunker"
-	uuid "github.com/satori/go.uuid"
 )
 
+func UploadProject(dir string, kw KeyWriter, concurrency int, s3 *S3) error {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("failed to inspect '%s' for commit: %v", dir, err)
+	} else if !fi.IsDir() {
+		return fmt.Errorf("provided path '%s' is not a directory", dir)
+	}
+
+	id, err := GetProjectID(dir)
+	if err != nil {
+		return fmt.Errorf("could not get project ID: %v", err)
+	}
+
+	keyReader := KeyReadWriter()
+	doneCh := make(chan error)
+	pr, pw := io.Pipe()
+	cr := chunker.New(pr, chunker.Pol(0x3DA3358B4DC173))
+	go func() {
+		doneCh <- Upload(cr, keyReader, concurrency, s3)
+	}()
+
+	err = Tar(dir, pw)
+	if err != nil {
+		return fmt.Errorf("failed to tar '%s': %v", dir, err)
+	}
+
+	pw.Close()
+	err = <-doneCh
+	if err != nil {
+		return fmt.Errorf("failed to upload: %v", err)
+	}
+	//push index file
+	buf := new(bytes.Buffer)
+	for k, e := keyReader.Read(); e == nil; k, e = keyReader.Read() {
+		err = kw.Write(k)
+		if err != nil {
+			return fmt.Errorf("failed to write key: %v", err)
+		}
+		buf.WriteString(fmt.Sprintf("%x\n", k))
+	}
+	err = s3.Put(BucketMetadata, id, buf) //if not exists put
+	if err != nil {
+		return fmt.Errorf("failed to put metadata file with uuid %v: %v", id, err)
+	}
+	return nil
+}
+
 //Upload pushes chunks to s3 and writes them
-func Upload(cr *chunker.Chunker, kw KeyWriter, concurrency int, s3 *S3, id uuid.UUID) (err error) {
+func Upload(cr *chunker.Chunker, kw KeyWriter, concurrency int, s3 *S3) (err error) {
 	type result struct {
 		err error
 		k   K
@@ -25,15 +72,15 @@ func Upload(cr *chunker.Chunker, kw KeyWriter, concurrency int, s3 *S3, id uuid.
 
 	work := func(it *item) {
 		var exists bool
-		k := sha256.Sum256(it.chunk)              //hash
-		exists, err = s3.Has(BucketContent, k[:]) //check existence
+		var k K = sha256.Sum256(it.chunk)                 //hash
+		exists, err = s3.Has(BucketContent, k.ToString()) //check existence
 		if err != nil {
 			it.resCh <- &result{fmt.Errorf("failed to check existence of '%x': %v", k, err), ZeroKey}
 			return
 		}
 
 		if !exists {
-			err = s3.Put(BucketContent, k[:], bytes.NewBuffer(it.chunk)) //if not exists put
+			err = s3.Put(BucketContent, k.ToString(), bytes.NewBuffer(it.chunk)) //if not exists put
 			if err != nil {
 				it.resCh <- &result{fmt.Errorf("failed to put chunk '%x': %v", k, err), ZeroKey}
 				return
@@ -90,16 +137,5 @@ func Upload(cr *chunker.Chunker, kw KeyWriter, concurrency int, s3 *S3, id uuid.
 			return fmt.Errorf("failed to write key: %v", err)
 		}
 	}
-
-	//push index file
-	buf := new(bytes.Buffer)
-	for _, k := range keys {
-		buf.WriteString(fmt.Sprintf("%x\n", k))
-	}
-	err = s3.Put(BucketMetadata, id[:], buf) //if not exists put
-	if err != nil {
-		return fmt.Errorf("failed to put metadata file with uuid %v: %v", id, err)
-	}
-
 	return nil
 }

--- a/s3sync/utils.go
+++ b/s3sync/utils.go
@@ -1,0 +1,125 @@
+package s3sync
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/dchest/safefile"
+	uuid "github.com/hashicorp/go-uuid"
+)
+
+//ProjectIDFile contains the nerdalize storage project ID for a given folder.
+const ProjectIDFile = ".nlz-storage-project"
+
+type keys struct {
+	*sync.Mutex
+	pos int
+	M   map[K]struct{}
+	L   []K
+}
+
+func KeyReadWriter() *keys {
+	return &keys{Mutex: &sync.Mutex{}, M: map[K]struct{}{}}
+}
+
+func (kw *keys) Write(k K) error {
+	kw.Lock()
+	defer kw.Unlock()
+	if _, ok := kw.M[k]; ok {
+		return nil
+	}
+
+	kw.M[k] = struct{}{}
+	kw.L = append(kw.L, k)
+	return nil
+}
+
+func (kw *keys) Read() (k K, err error) {
+	kw.Lock()
+	defer kw.Unlock()
+	if kw.pos == len(kw.L) {
+		return ZeroKey, io.EOF
+	}
+
+	k = kw.L[kw.pos]
+	kw.pos = kw.pos + 1
+	return k, nil
+}
+
+//GetProjectID returns the nerdalize storage project ID for a given folder.
+func GetProjectID(dirPath string) (string, error) {
+	file := path.Join(dirPath, ProjectIDFile)
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		id, err := uuid.GenerateUUID()
+		if err != nil {
+			return "", fmt.Errorf("could not generate uuid: %v", err)
+		}
+		f, err := os.Create(file)
+		defer f.Close()
+		if err != nil {
+			return "", fmt.Errorf("could not create project ID file '%v': %v", file, err)
+		}
+		f.Write([]byte(id))
+		f.Sync()
+		return id, nil
+	}
+	dat, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("could not read project ID file '%v': %v", file, err)
+	}
+	return string(dat), nil
+}
+
+func untardir(dir string, r io.Reader) (err error) {
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return fmt.Errorf("failed to read next tar header: %v", err)
+		}
+
+		path := filepath.Join(dir, hdr.Name)
+		err = os.MkdirAll(filepath.Dir(path), 0777)
+		if err != nil {
+			return fmt.Errorf("failed to create dirs: %v", err)
+		}
+
+		f, err := safefile.Create(path, os.FileMode(hdr.Mode))
+		if err != nil {
+			return fmt.Errorf("failed to create tmp safe file: %v", err)
+		}
+
+		defer f.Close()
+		n, err := io.Copy(f, tr)
+		if err != nil {
+			return fmt.Errorf("failed to write file content to tmp file: %v", err)
+		}
+
+		if n != hdr.Size {
+			return fmt.Errorf("unexpected nr of bytes written, wrote '%d' saw '%d' in tar hdr", n, hdr.Size)
+		}
+
+		err = f.Commit()
+		if err != nil {
+			return fmt.Errorf("failed to swap old file for tmp file: %v", err)
+		}
+
+		err = os.Chtimes(path, time.Now(), hdr.ModTime)
+		if err != nil {
+			return fmt.Errorf("failed to change times of tmp file: %v", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR allows folders to be uploaded and downloaded, which could be identified by means of an UUID. 
Each folder that is uploaded is now considered to be a "project", which is universally uniquely identifiable. This works as follows:
When a user choses to upload a folder a hidden file (.nlz-storage-project) is created (if it does not already exists) in this folder containing an UUID. This UUID can now be used to pull the directory on other machines. 

The CLI commands are now as follows:
- `s3sync push <dir>`
- `s3sync pull <uuid> <output_dir>`

The added functionality is mainly reflected in `s3sync/upload.go` and `s3sync/download.go`. 